### PR TITLE
Confirm on edit submission

### DIFF
--- a/public/locales/en/main.json
+++ b/public/locales/en/main.json
@@ -45,6 +45,6 @@
   "cloneChat": "Clone Chat",
   "cloned": "Cloned",
   "enterToSubmit": "Enter to submit",
-  "confirmEditSubmission": "Confirm before sending edited chat",
-  "submitPlaceholder": "Type a message or click [/] for prompts..."
+  "submitPlaceholder": "Type a message or click [/] for prompts...",
+  "confirmEditSubmission": "Confirm before sending edited chat"
 }

--- a/public/locales/en/main.json
+++ b/public/locales/en/main.json
@@ -45,5 +45,6 @@
   "cloneChat": "Clone Chat",
   "cloned": "Cloned",
   "enterToSubmit": "Enter to submit",
+  "confirmEditSubmission": "Confirm before sending edited chat",
   "submitPlaceholder": "Type a message or click [/] for prompts..."
 }

--- a/src/components/Chat/ChatContent/Message/View/EditView.tsx
+++ b/src/components/Chat/ChatContent/Message/View/EditView.tsx
@@ -27,6 +27,8 @@ const EditView = ({
 
   const [_content, _setContent] = useState<string>(content);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+
   const textareaRef = React.createRef<HTMLTextAreaElement>();
 
   const { t } = useTranslation();
@@ -74,6 +76,8 @@ const EditView = ({
 
   const { handleSubmit } = useSubmit();
   const handleSaveAndSubmit = () => {
+    console.log("ass")
+
     if (useStore.getState().generating) return;
     const updatedChats: ChatInterface[] = JSON.parse(
       JSON.stringify(useStore.getState().chats)
@@ -115,8 +119,8 @@ const EditView = ({
     <>
       <div
         className={`w-full ${sticky
-            ? 'py-2 md:py-3 px-2 md:px-4 border border-black/10 bg-white dark:border-gray-900/50 dark:text-white dark:bg-gray-700 rounded-md shadow-[0_0_10px_rgba(0,0,0,0.10)] dark:shadow-[0_0_15px_rgba(0,0,0,0.10)]'
-            : ''
+          ? 'py-2 md:py-3 px-2 md:px-4 border border-black/10 bg-white dark:border-gray-900/50 dark:text-white dark:bg-gray-700 rounded-md shadow-[0_0_10px_rgba(0,0,0,0.10)] dark:shadow-[0_0_15px_rgba(0,0,0,0.10)]'
+          : ''
           }`}
       >
         <textarea
@@ -139,6 +143,11 @@ const EditView = ({
         setIsEdit={setIsEdit}
         _setContent={_setContent}
       />
+
+//POINT 1
+
+
+
       {isModalOpen && (
         <PopupModal
           setIsModalOpen={setIsModalOpen}
@@ -146,7 +155,8 @@ const EditView = ({
           message={t('clearMessageWarning') as string}
           handleConfirm={handleSaveAndSubmit}
         />
-      )}
+      )
+      }
     </>
   );
 };
@@ -188,9 +198,9 @@ const EditViewButtons = memo(
 
           <button
             className={`btn relative mr-2 ${sticky
-                ? `btn-neutral ${generating ? 'cursor-not-allowed opacity-40' : ''
-                }`
-                : 'btn-primary'
+              ? `btn-neutral ${generating ? 'cursor-not-allowed opacity-40' : ''
+              }`
+              : 'btn-primary'
               }`}
             onClick={handleSave}
           >
@@ -203,7 +213,12 @@ const EditViewButtons = memo(
             <button
               className='btn relative mr-2 btn-neutral'
               onClick={() => {
-                !generating && setIsModalOpen(true);
+                const confirmEditSubmit = useStore.getState().confirmEditSubmit
+                if (confirmEditSubmit)
+                  !generating && setIsModalOpen(true);
+                else
+                  handleSaveAndSubmit();
+
               }}
             >
               <div className='flex items-center justify-center gap-2'>

--- a/src/components/Chat/ChatContent/Message/View/EditView.tsx
+++ b/src/components/Chat/ChatContent/Message/View/EditView.tsx
@@ -144,10 +144,6 @@ const EditView = ({
         _setContent={_setContent}
       />
 
-//POINT 1
-
-
-
       {isModalOpen && (
         <PopupModal
           setIsModalOpen={setIsModalOpen}

--- a/src/components/Chat/ChatContent/Message/View/EditView.tsx
+++ b/src/components/Chat/ChatContent/Message/View/EditView.tsx
@@ -114,11 +114,10 @@ const EditView = ({
   return (
     <>
       <div
-        className={`w-full ${
-          sticky
+        className={`w-full ${sticky
             ? 'py-2 md:py-3 px-2 md:px-4 border border-black/10 bg-white dark:border-gray-900/50 dark:text-white dark:bg-gray-700 rounded-md shadow-[0_0_10px_rgba(0,0,0,0.10)] dark:shadow-[0_0_15px_rgba(0,0,0,0.10)]'
             : ''
-        }`}
+          }`}
       >
         <textarea
           ref={textareaRef}
@@ -177,9 +176,8 @@ const EditViewButtons = memo(
         <div className='flex-1 text-center mt-2 flex justify-center'>
           {sticky && (
             <button
-              className={`btn relative mr-2 btn-primary ${
-                generating ? 'cursor-not-allowed opacity-40' : ''
-              }`}
+              className={`btn relative mr-2 btn-primary ${generating ? 'cursor-not-allowed opacity-40' : ''
+                }`}
               onClick={handleSaveAndSubmit}
             >
               <div className='flex items-center justify-center gap-2'>
@@ -189,13 +187,11 @@ const EditViewButtons = memo(
           )}
 
           <button
-            className={`btn relative mr-2 ${
-              sticky
-                ? `btn-neutral ${
-                    generating ? 'cursor-not-allowed opacity-40' : ''
-                  }`
+            className={`btn relative mr-2 ${sticky
+                ? `btn-neutral ${generating ? 'cursor-not-allowed opacity-40' : ''
+                }`
                 : 'btn-primary'
-            }`}
+              }`}
             onClick={handleSave}
           >
             <div className='flex items-center justify-center gap-2'>

--- a/src/components/Chat/ChatContent/Message/View/EditView.tsx
+++ b/src/components/Chat/ChatContent/Message/View/EditView.tsx
@@ -27,8 +27,6 @@ const EditView = ({
 
   const [_content, _setContent] = useState<string>(content);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-
-
   const textareaRef = React.createRef<HTMLTextAreaElement>();
 
   const { t } = useTranslation();
@@ -76,8 +74,6 @@ const EditView = ({
 
   const { handleSubmit } = useSubmit();
   const handleSaveAndSubmit = () => {
-    console.log("ass")
-
     if (useStore.getState().generating) return;
     const updatedChats: ChatInterface[] = JSON.parse(
       JSON.stringify(useStore.getState().chats)
@@ -143,7 +139,6 @@ const EditView = ({
         setIsEdit={setIsEdit}
         _setContent={_setContent}
       />
-
       {isModalOpen && (
         <PopupModal
           setIsModalOpen={setIsModalOpen}

--- a/src/components/ConfigMenu/ConfigMenu.tsx
+++ b/src/components/ConfigMenu/ConfigMenu.tsx
@@ -92,9 +92,8 @@ export const ModelSelector = ({
       </button>
       <div
         id='dropdown'
-        className={`${
-          dropDown ? '' : 'hidden'
-        } absolute top-100 bottom-100 z-10 bg-white rounded-lg shadow-xl border-b border-black/10 dark:border-gray-900/50 text-gray-800 dark:text-gray-100 group dark:bg-gray-800 opacity-90`}
+        className={`${dropDown ? '' : 'hidden'
+          } absolute top-100 bottom-100 z-10 bg-white rounded-lg shadow-xl border-b border-black/10 dark:border-gray-900/50 text-gray-800 dark:text-gray-100 group dark:bg-gray-800 opacity-90`}
       >
         <ul
           className='text-sm text-gray-700 dark:text-gray-200 p-0 m-0'

--- a/src/components/SettingsMenu/ConfirmEditSubmission.tsx
+++ b/src/components/SettingsMenu/ConfirmEditSubmission.tsx
@@ -6,14 +6,18 @@ import Toggle from '@components/Toggle';
 const ConfirmEditSubmissionToggle = () => {
     const { t } = useTranslation();
 
-    const setConfirmEditSubmission = useStore((state) => state.setEnterToSubmit);
+    const setConfirmEditSubmission = useStore((state) => state.setConfirmEditSubmission);
 
     const [isChecked, setIsChecked] = useState<boolean>(
-        useStore.getState().enterToSubmit
+        useStore.getState().confirmEditSubmit
     );
 
     useEffect(() => {
         setConfirmEditSubmission(isChecked);
+
+        console.log("set to (readback): " + useStore.getState().confirmEditSubmit)
+
+
     }, [isChecked]);
 
     return (

--- a/src/components/SettingsMenu/ConfirmEditSubmission.tsx
+++ b/src/components/SettingsMenu/ConfirmEditSubmission.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import useStore from '@store/store';
+import Toggle from '@components/Toggle';
+
+const ConfirmEditSubmissionToggle = () => {
+    const { t } = useTranslation();
+
+    const setConfirmEditSubmission = useStore((state) => state.setEnterToSubmit);
+
+    const [isChecked, setIsChecked] = useState<boolean>(
+        useStore.getState().enterToSubmit
+    );
+
+    useEffect(() => {
+        setConfirmEditSubmission(isChecked);
+    }, [isChecked]);
+
+    return (
+        <Toggle
+            label={t('confirmEditSubmission') as string}
+            isChecked={isChecked}
+            setIsChecked={setIsChecked}
+        />
+    );
+};
+
+export default ConfirmEditSubmissionToggle;

--- a/src/components/SettingsMenu/ConfirmEditSubmission.tsx
+++ b/src/components/SettingsMenu/ConfirmEditSubmission.tsx
@@ -15,9 +15,6 @@ const ConfirmEditSubmissionToggle = () => {
     useEffect(() => {
         setConfirmEditSubmission(isChecked);
 
-        console.log("set to (readback): " + useStore.getState().confirmEditSubmit)
-
-
     }, [isChecked]);
 
     return (

--- a/src/components/SettingsMenu/SettingsMenu.tsx
+++ b/src/components/SettingsMenu/SettingsMenu.tsx
@@ -59,7 +59,6 @@ const SettingsMenu = () => {
               {isElectron() && <CloseToTrayToggle />}
               <AutoTitleToggle />
               <EnterToSubmitToggle />
-              <p>asdf</p>
               <ConfirmEditSubmissionToggle />
               <InlineLatexToggle />
               <AdvancedModeToggle />

--- a/src/components/SettingsMenu/SettingsMenu.tsx
+++ b/src/components/SettingsMenu/SettingsMenu.tsx
@@ -19,6 +19,7 @@ import TotalTokenCost, { TotalTokenCostToggle } from './TotalTokenCost';
 import ClearConversation from '@components/Menu/MenuOptions/ClearConversation';
 import ImportExportChat from '@components/ImportExportChat/ImportExportChat';
 import Api from '@components/Menu/MenuOptions/Api';
+import ConfirmEditSubmissionToggle from './ConfirmEditSubmission';
 
 
 const SettingsMenu = () => {
@@ -58,6 +59,8 @@ const SettingsMenu = () => {
               {isElectron() && <CloseToTrayToggle />}
               <AutoTitleToggle />
               <EnterToSubmitToggle />
+              <p>asdf</p>
+              <ConfirmEditSubmissionToggle />
               <InlineLatexToggle />
               <AdvancedModeToggle />
               <TotalTokenCostToggle />

--- a/src/store/chat-slice.ts
+++ b/src/store/chat-slice.ts
@@ -14,6 +14,8 @@ export interface ChatSlice {
   setGenerating: (generating: boolean) => void;
   setError: (error: string) => void;
   setFolders: (folders: FolderCollection) => void;
+  setConfirmEditSubmission: (confirmEditSubmission: boolean) => void;
+
 }
 
 export const createChatSlice: StoreSlice<ChatSlice> = (set, get) => ({
@@ -58,4 +60,10 @@ export const createChatSlice: StoreSlice<ChatSlice> = (set, get) => ({
       folders: folders,
     }));
   },
+  setConfirmEditSubmission: (confirmEditSubmission: Boolean) => {
+    set((prev: ChatSlice) => ({
+      ...prev,
+      confirmEditSubmission: confirmEditSubmission,
+    }));
+  }
 });

--- a/src/store/chat-slice.ts
+++ b/src/store/chat-slice.ts
@@ -15,7 +15,6 @@ export interface ChatSlice {
   setError: (error: string) => void;
   setFolders: (folders: FolderCollection) => void;
   setConfirmEditSubmission: (confirmEditSubmission: boolean) => void;
-
 }
 
 export const createChatSlice: StoreSlice<ChatSlice> = (set, get) => ({

--- a/src/store/config-slice.ts
+++ b/src/store/config-slice.ts
@@ -28,6 +28,7 @@ export interface ConfigSlice {
   setHideMenuOptions: (hideMenuOptions: boolean) => void;
   setHideSideMenu: (hideSideMenu: boolean) => void;
   setEnterToSubmit: (enterToSubmit: boolean) => void;
+  setConfirmEditSubmission: (confirmEditSubmit: boolean) => void;
   setInlineLatex: (inlineLatex: boolean) => void;
   setMarkdownMode: (markdownMode: boolean) => void;
   setCountTotalTokens: (countTotalTokens: boolean) => void;
@@ -108,6 +109,12 @@ export const createConfigSlice: StoreSlice<ConfigSlice> = (set, get) => ({
       ...prev,
       enterToSubmit: enterToSubmit,
     }));
+  },
+  setConfirmEditSubmission: (confirmEditSubmit: boolean) => {
+    set((prev: ConfigSlice) => ({
+      ...prev,
+      confirmEditSubmit: confirmEditSubmit,
+    }))
   },
   setInlineLatex: (inlineLatex: boolean) => {
     set((prev: ConfigSlice) => ({

--- a/src/store/config-slice.ts
+++ b/src/store/config-slice.ts
@@ -14,6 +14,7 @@ export interface ConfigSlice {
   defaultSystemMessage: string;
   hideSideMenu: boolean;
   enterToSubmit: boolean;
+  confirmEditSubmit: boolean;
   inlineLatex: boolean;
   markdownMode: boolean;
   countTotalTokens: boolean;
@@ -43,6 +44,7 @@ export const createConfigSlice: StoreSlice<ConfigSlice> = (set, get) => ({
   autoTitle: false,
   closeToTray: false,
   enterToSubmit: true,
+  confirmEditSubmit: true,
   advancedMode: true,
   defaultChatConfig: _defaultChatConfig,
   defaultSystemMessage: _defaultSystemMessage,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -55,6 +55,7 @@ export const createPartializedState = (state: StoreState) => ({
   firstVisit: state.firstVisit,
   hideSideMenu: state.hideSideMenu,
   folders: state.folders,
+  confirmOnEditSubmission: state.setConfirmEditSubmission,
   enterToSubmit: state.enterToSubmit,
   inlineLatex: state.inlineLatex,
   markdownMode: state.markdownMode,


### PR DESCRIPTION
## Added ConfirmEditSubmission setting:
- input control switch in user settings
- If this setting is disabled, submitting an edited message will send it right away - _without_ the confirmation dialog.
  *(when submitting while editing an _existing_ message)*

<br><br>

![image](https://github.com/jackschedel/gpt.koaladev.io/assets/54555500/c865c66a-6baa-4dbf-a755-a3af80252042)

