### PR TITLE
Disable chat dragging while editing title

### DIFF
--- a/src/components/Menu/ChatHistory.tsx
+++ b/src/components/Menu/ChatHistory.tsx
@@ -92,7 +92,7 @@ const ChatHistory = React.memo(
         onClick={() => {
           if (!generating) setCurrentChatIndex(chatIndex);
         }}
-        draggable
+        draggable={!isEdit}
         onDragStart={handleDragStart}
       >
         <ChatIcon />


### PR DESCRIPTION
### Changes made:
The draggable property within the ChatHistory component has been updated with a conditional check based on the isEdit state. When in edit mode, the draggable property is set to false, preventing unintended drag interactions.

Closes #57 